### PR TITLE
feat: add ResetButtons component for field reset functionality

### DIFF
--- a/src/components/ResetButtons.jsx
+++ b/src/components/ResetButtons.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+const ResetButtons = ({ field, fields, setFields, isResetAll = false }) => {
+  const handleResetField = () => {
+    setFields({ ...fields, [field]: "" });
+  };
+
+  const handleResetAll = () => {
+    if (window.confirm("Are you sure you want to reset all fields?")) {
+      setFields(
+        Object.keys(fields).reduce((acc, key) => ({ ...acc, [key]: "" }), {})
+      );
+    }
+  };
+
+  return (
+    <button
+      onClick={isResetAll ? handleResetAll : handleResetField}
+      className="mt-2 p-2 bg-gray-200 hover:bg-gray-300 text-black rounded-full"
+    >
+      {isResetAll ? "Reset All" : "Reset Field"}
+    </button>
+  );
+};
+
+export default ResetButtons;


### PR DESCRIPTION
### Description
This PR implements the `ResetButtons` component, which provides the functionality to reset individual form fields or all fields at once. The component has been designed to be integrated into a larger form page (which will be handled separately), but it is ready to be used for resetting the specified fields.

### Changes
- **Feature:**
  - Created `ResetButtons` component to reset individual fields and reset all fields with user confirmation.

### How to Test
1. Use the `ResetButtons` component in a form by passing `fields` and `setFields` state as props.
2. Test the following scenarios:
   - **Reset Field**: Click the "Reset Field" button for each field. Ensure that only the respective field is cleared.
   - **Reset All**: Click the "Reset All" button and confirm the action. Ensure that all fields are cleared.

### Notes for Integration:
- The actual **form page** and **fields state** (`persona`, `context`, `task`, `output`, `constraint`) will be implemented in a separate task.
- This PR only covers the button functionality and provides the necessary logic for resetting fields. It should be integrated with the form page later where the form state will be managed.
