### PR TITLE
WIP - PromptHistory Button -Save

### DIFF
--- a/src/components/Pentagram.jsx
+++ b/src/components/Pentagram.jsx
@@ -7,6 +7,8 @@ import ResetButtons from "./ResetButtons.jsx";
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import "../HandleLoading.css";
 
+import PromptHistory from "./PromptHistory.jsx";
+
 const PentagramContent = () => {
   const { index, setIndex, pentaPrompts, inputs } = usePentagram();
   const [responseText, setResponseText] = useState(null);
@@ -109,6 +111,8 @@ const PentagramContent = () => {
         >
           Back
         </button>
+
+        <PromptHistory />
 
         <button
           onClick={index === 4 ? handleSubmit : onNext}

--- a/src/components/PromptHistory.jsx
+++ b/src/components/PromptHistory.jsx
@@ -1,30 +1,25 @@
-import React from 'react';
+import React, {useEffect} from 'react';
+import { usePentagram } from './PentagramContext';
 
-const PromptHistory = ({ prompts }) => {
+const PromptHistory = () => {
+  const { inputs, setInputs } = usePentagram();
 
-  // const dataToSave = prompts || {
-  //   prompt1: 'Mock Prompt 1',
-  //   prompt2: 'Mock Prompt 2',
-  //   prompt2: 'Mock Prompt 3', 
-  // };
-
-  const savePrompts = () => {
-    const promptArray = Object.values(dataToSave);
-
-    if (promptArray.some((prompt) => prompt.trim() === '')) {
-      console.log('Some prompts are empty, not saving');
-      return;
+  useEffect(() => {
+    const savedPrompts = localStorage.getItem('pentagramPrompts');
+    if (savedPrompts) {
+      setInputs(JSON.parse(savedPrompts));
     }
-
-    const savedPrompts = JSON.parse(localStorage.getItem('promptHistory')) || [];
-    savedPrompts.push(promptArray);
-    localStorage.setItem('promptHistory', JSON.stringify(savedPrompts));
-
-    console.log('Prompts saved:', promptArray);
+  }, [setInputs]);
+  
+  const handleSave = () => {
+    localStorage.setItem('pentagramPrompts', JSON.stringify(inputs));
   };
-    
+
   return (
-    <button onClick={savePrompts}>Save Prompts</button>
+    <button 
+      className="px-6 py-2 rounded-md bg-blue-300 text-blue-500 mt-3"
+      onClick={handleSave}>Save Prompt
+    </button>
   );
 };
 


### PR DESCRIPTION
Updated and imported the component into the Pentagram.jsx file. The button works and can save each prompt individually.

### Description
Can save each prompt (individually per prompt) to the local storage. ***Cannot** save all 5 prompts at one time.***

### Changes
updated the Pentagram.jsx file to include the PromptHistory.jsx component. 
Set the button to the left of the Next and Submit buttons

### Screenshots (if applicable)
![savePrompt2](https://github.com/user-attachments/assets/76ab8200-5ccb-4852-93de-bfccfa0f70e1)
![saveprompt](https://github.com/user-attachments/assets/c833b204-24ab-4982-8949-1399b6301e30)


### How to Test
1. open the prompt-history branch
2. type in each input and hit save
3. open inspector tool 
4. go to local storage
5. view results

### Checklist
- [ ] Code follows project guidelines
- [ ] Tests pass
- [ ] No merge conflicts
- [ ] Ready for review
