### PR TITLE
Help menu new

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -46,7 +46,7 @@ function Header() {
   };
 
   useEffect(() => {
-    setCurrentDate(format(getDate(), "MM/dd/yyyy"));
+    setCurrentDate(format(getDate(), "MM.dd.yyyy"));
   }, []);
 
   useEffect(() => {

--- a/src/components/helpMenu/HelpMenu.jsx
+++ b/src/components/helpMenu/HelpMenu.jsx
@@ -48,13 +48,13 @@ const HelpMenu = ({ width, position, isOpen, onRequestClose }) => {
 
   return (
     <div
-      className={`font-Inconsolata-Regular fixed top-0 right-0 bg-white/[0.65] w-full h-screen z-40 transition-opacity duration-300
+      className={`font-Inconsolata-Regular fixed top-0 right-0 backdrop-blur-xs w-full h-screen z-40 transition-blur duration-300
         ${isOpen ? "opacity-100" : "opacity-0"} ${
         isVisible ? "" : "invisible"
       }`}
     >
       <div
-        className={`bg-gradient-to-b from-[#02010B] to-[#0D00A4] ${width} absolute ${position} h-full shadow-lg transform transition-transform duration-700
+        className={`bg-black ${width} absolute ${position} h-full shadow-lg transform transition-transform duration-700
           ${isOpen ? "translate-x-0" : "translate-x-full"} overflow-y-auto`}
       >
         <div className=" w-full flex flex-col gap-5">
@@ -64,7 +64,7 @@ const HelpMenu = ({ width, position, isOpen, onRequestClose }) => {
             </h2>
             <button
               onClick={onRequestClose}
-              className="sm:pt-10 md:pt-10 text-white text-4xl hover:text-blue-400  cursor-pointer rounded-2xl"
+              className="sm:pt-10 md:pt-10 text-blue-300 text-4xl hover:text-blue-400  cursor-pointer rounded-2xl"
             >
               <FaWindowClose />
             </button>

--- a/src/components/helpMenu/HelpMenu.jsx
+++ b/src/components/helpMenu/HelpMenu.jsx
@@ -58,13 +58,13 @@ const HelpMenu = ({ width, position, isOpen, onRequestClose }) => {
           ${isOpen ? "translate-x-0" : "translate-x-full"} overflow-y-auto`}
       >
         <div className=" w-full flex flex-col gap-5">
-          <div className="flex items-center justify-between px-2 pt-10 ">
-            <h2 className="text-gray-300  text-2xl font-bold underline">
+          <div className="flex items-center justify-between px-2 pt-5 ">
+            <h2 className="text-gray-300 text-2xl font-bold underline">
               {helpDataObject?.introduction.title}
             </h2>
             <button
               onClick={onRequestClose}
-              className="sm:pt-10 md:pt-10 text-blue-300 text-4xl hover:text-blue-400  cursor-pointer rounded-2xl"
+              className=" text-blue-300 text-4xl hover:text-blue-400  cursor-pointer rounded-2xl"
             >
               <FaWindowClose />
             </button>

--- a/src/components/helpMenu/HelpMenu.jsx
+++ b/src/components/helpMenu/HelpMenu.jsx
@@ -54,7 +54,7 @@ const HelpMenu = ({ width, position, isOpen, onRequestClose }) => {
       }`}
     >
       <div
-        className={`bg-gray-300 ${width} absolute ${position} h-full shadow-lg transform transition-transform duration-700
+        className={`bg-blue-100 ${width} absolute ${position} h-full shadow-lg transform transition-transform duration-700
           ${isOpen ? "translate-x-0" : "translate-x-full"} overflow-y-auto`}
       >
         <div className=" w-full flex flex-col gap-5">

--- a/src/components/helpMenu/HelpMenu.jsx
+++ b/src/components/helpMenu/HelpMenu.jsx
@@ -48,30 +48,30 @@ const HelpMenu = ({ width, position, isOpen, onRequestClose }) => {
 
   return (
     <div
-      className={`font-Inconsolata-Regular fixed top-0 right-0 bg-black/[0.65] w-full h-screen z-40 transition-opacity duration-300
+      className={`font-Inconsolata-Regular fixed top-0 right-0 bg-white/[0.65] w-full h-screen z-40 transition-opacity duration-300
         ${isOpen ? "opacity-100" : "opacity-0"} ${
         isVisible ? "" : "invisible"
       }`}
     >
       <div
-        className={`bg-blue-100 ${width} absolute ${position} h-full shadow-lg transform transition-transform duration-700
+        className={`bg-gradient-to-b from-[#02010B] to-[#0D00A4] ${width} absolute ${position} h-full shadow-lg transform transition-transform duration-700
           ${isOpen ? "translate-x-0" : "translate-x-full"} overflow-y-auto`}
       >
         <div className=" w-full flex flex-col gap-5">
           <div className="flex items-center justify-between px-2 pt-10 ">
-            <h2 className="text-neutral-900  text-2xl font-bold underline">
+            <h2 className="text-gray-300  text-2xl font-bold underline">
               {helpDataObject?.introduction.title}
             </h2>
             <button
               onClick={onRequestClose}
-              className="sm:pt-10 md:pt-10 text-neutral-900 text-4xl hover:text-gray-700  cursor-pointer rounded-2xl"
+              className="sm:pt-10 md:pt-10 text-white text-4xl hover:text-blue-400  cursor-pointer rounded-2xl"
             >
               <FaWindowClose />
             </button>
           </div>
           <div className="text-center flex flex-col gap-3 mb-4">
-            <h2 className="text-center text-3xl font-bold">{welcome}</h2>
-            <p className="mx-1">{welcomeContent}</p>
+            <h2 className="text-center text-white text-3xl font-bold">{welcome}</h2>
+            <p className="text-white mx-2">{welcomeContent}</p>
           </div>
         </div>
 

--- a/src/components/helpMenu/HelpMenu.jsx
+++ b/src/components/helpMenu/HelpMenu.jsx
@@ -48,7 +48,7 @@ const HelpMenu = ({ width, position, isOpen, onRequestClose }) => {
 
   return (
     <div
-      className={`font-Inconsolata-Regular fixed top-0 right-0 backdrop-blur-xs w-full h-screen z-40 transition-blur duration-300
+      className={`font-Inconsolata-Regular fixed top-0 right-0 bg-black/[0.70] w-full h-screen z-40 transition-blur duration-300
         ${isOpen ? "opacity-100" : "opacity-0"} ${
         isVisible ? "" : "invisible"
       }`}

--- a/src/components/helpMenu/helpMenuSections/AdvanceFeatures.jsx
+++ b/src/components/helpMenu/helpMenuSections/AdvanceFeatures.jsx
@@ -10,7 +10,7 @@ export default function AdvanceFeatures({
     <section className="p-4">
         <button
         onClick={() => toggleSection(sectionId)}
-        className="w-full text-left flex justify-between items-center bg-gray-100 p-3 rounded-md hover:bg-gray-200"
+        className="w-full text-left flex justify-between items-center bg-blue-200 p-3 rounded-md hover:bg-blue-300"
       >
         <h2 className="text-2xl font-bold">{data.title}</h2>
         <span className="text-xl">
@@ -27,9 +27,9 @@ export default function AdvanceFeatures({
       >
         {data.sections.map((section, index) => (
           <div key={index} className="mb-8">
-            <h3 className="mb-3">{section.heading}</h3>
+            <h3 className="text-white mb-3">{section.heading}</h3>
 
-            <ul className="list-disc pl-5 space-y-2 text-gray-700">
+            <ul className="list-disc pl-5 space-y-2 text-gray-400">
               {section.features.map((feature, i) => (
                 <li key={i}>{feature}</li>
               ))}

--- a/src/components/helpMenu/helpMenuSections/Faq.jsx
+++ b/src/components/helpMenu/helpMenuSections/Faq.jsx
@@ -4,7 +4,7 @@ export default function Faq({ data, toggleSection, isSectionOpen }) {
     <section className="p-4">
       <button
         onClick={() => toggleSection(sectionId)}
-        className="w-full text-left flex justify-between items-center bg-gray-100 p-3 rounded-md hover:bg-gray-200"
+        className="w-full text-left flex justify-between items-center bg-blue-200 p-3 rounded-md hover:bg-blue-300"
       >
         <h2 className="text-2xl font-bold">{data.title}</h2>
         <span className="text-xl">
@@ -21,11 +21,11 @@ export default function Faq({ data, toggleSection, isSectionOpen }) {
       >
         {data.sections.map((section, index) => (
           <div key={index} className="mb-8">
-            <h3 className="text-xl font-semibold  mb-3">{section.heading}</h3>
+            <h3 className="text-xl text-white font-semibold  mb-3">{section.heading}</h3>
 
             <div className="space-y-4">
               {section.questions.map((qa, i) => (
-                <div key={i} className="bg-white shadow rounded-lg p-4">
+                <div key={i} className="bg-blue-100 shadow rounded-lg p-4">
                   <p className="font-medium ">{qa.question}</p>
                   <p className="text-sm whitespace-pre-line">{qa.answer}</p>
                 </div>

--- a/src/components/helpMenu/helpMenuSections/GettingStarted.jsx
+++ b/src/components/helpMenu/helpMenuSections/GettingStarted.jsx
@@ -4,7 +4,7 @@ export default function GettingStarted({ data, toggleSection, isSectionOpen }) {
     <section className="p-4">
       <button
         onClick={() => toggleSection(sectionId)}
-        className="w-full text-left flex justify-between items-center bg-gray-100 p-3 rounded-md hover:bg-gray-200"
+        className="w-full text-left flex justify-between items-center bg-blue-200 p-3 rounded-md hover:bg-blue-300"
       >
         <h2 className="text-2xl font-bold">{data.title}</h2>
         <span className="text-xl">
@@ -21,12 +21,12 @@ export default function GettingStarted({ data, toggleSection, isSectionOpen }) {
       >
         {data.sections.map((section, idx) => (
           <div key={idx} className="mb-6">
-            <h3 className="text-xl font-semibold mb-2">{section.heading}</h3>
+            <h3 className="text-xl text-white font-semibold mb-2">{section.heading}</h3>
             {section.content && (
-              <p className="text-base mb-2">{section.content}</p>
+              <p className="text-base text-white mb-2">{section.content}</p>
             )}
             {section.steps && (
-              <ol className="list-decimal list-inside space-y-1">
+              <ol className="text-white list-decimal list-inside space-y-1">
                 {section.steps.map((step, i) => (
                   <li key={i}>{step}</li>
                 ))}
@@ -36,8 +36,8 @@ export default function GettingStarted({ data, toggleSection, isSectionOpen }) {
               <div className="mt-2 space-y-2">
                 {section.subsections.map((sub, i) => (
                   <div key={i} className="pl-4 border-l-4 border-blue-300">
-                    <p className="font-medium">{sub.name}</p>
-                    <p className="text-sm">{sub.description}</p>
+                    <p className="font-medium text-white">{sub.name}</p>
+                    <p className="text-sm text-white">{sub.description}</p>
                   </div>
                 ))}
               </div>


### PR DESCRIPTION
### Description
Changed to background, button, and text colors to match the rest of app.
When the help menu now opens, the transition-opacity was changed to white .65 since the help menu is now darker.  

### Changes
- [ ] **Feature:**
- [ ] **Fix:**
- [ ] **Refactor:**
- [ ] **Docs:**

### Screenshots (if applicable)
<!-- Attach visuals for UI changes -->
![Screenshot 2025-04-12 at 8 38 55 AM](https://github.com/user-attachments/assets/68c2c58d-1d16-4f4e-a676-b66009173ba7)
![Screenshot 2025-04-12 at 8 39 50 AM](https://github.com/user-attachments/assets/4c8ff591-4efd-4f6a-83dc-de7b7a06963b)
![Screenshot 2025-04-12 at 8 40 13 AM](https://github.com/user-attachments/assets/6c4d1bcb-a142-407d-88c2-c0a8ff049128)
![Screenshot 2025-04-12 at 8 40 50 AM](https://github.com/user-attachments/assets/746d5bb6-794e-4083-8e25-07f976a051d3)

### How to Test
1.

### Checklist
- [ ] Code follows project guidelines
- [ ] Tests pass
- [ ] No merge conflicts
- [ ] Ready for review
